### PR TITLE
Update thunder step range

### DIFF
--- a/spells/level-3/thunder-step.md
+++ b/spells/level-3/thunder-step.md
@@ -4,7 +4,7 @@
 ***3rd-level conjuration***
 - **Casting Time:** action
 - **Duration:** instantaneous
-- **Range:** touch
+- **Range:** 60 feet
 - **Instances:** 2
 - **Shape:** aura
 - **Radius:** 10 feet


### PR DESCRIPTION
Source Text: A spell from Xanathar's Guide To Everything
Conjuration

Level: 3
Casting time: 1 Action
Range: 90 feet
Components: V
Duration: Instantaneous
You teleport yourself to an unoccupied space you can see within range. Immediately after you disappear, a thunderous boom sounds, and each creature within 10 feet of the space you left must make a Constitution saving throw, taking 3d10 thunder damage on a failed save, or half as much damage on a successful one. The thunder can be heard from up to 300 feet away.
You can bring along objects as long as their weight doesn’t exceed what you can carry. You can also teleport one willing creature of your size or smaller who is carrying gear up to its carrying capacity. The creature must be within 5 feet of you when you cast this spell, and there must be an unoccupied space within 5 feet of your destination space for the creature to appear in; otherwise, the creature is left behind.

At higher level
When you cast this spell using a spell slot of 4th level or higher, the damage increases by 1d10 for each slot level above 3rd.